### PR TITLE
Fix docker build on BuildKit (now the default on Actions runners)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,13 +10,13 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    
+
     - name: Login to GitHub Container Registry
       run: |
         echo $GITHUB_TOKEN | docker login ghcr.io -u SteamDeckHomebrew --password-stdin
@@ -24,10 +24,12 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Download SteamOS
-      run: ./download.sh
+      id: download
+      run: ./download.sh >>$GITHUB_OUTPUT
 
-    - name: Build base image
-      run: sudo ./build.sh
+    - name: Build and tag base image
+      run: |
+        sudo ./build.sh
 
     - name: Cleanup SteamOS image
       run: rm -rf ./steamos_image ./steamos
@@ -42,19 +44,32 @@ jobs:
         cd languages
         docker build -t ghcr.io/steamdeckhomebrew/holo-toolchain-go:latest -f ./go.dockerfile .
 
+    - name: Tag all images
+      run: |
+        for tag in \
+            "${{ steps.download.outputs.BUILD_ID }}" \
+            "${{ steps.download.outputs.FULL_VERSION }}" \
+            "${{ steps.download.outputs.MAJOR_VERSION }}" \
+            "${{ steps.download.outputs.MINOR_VERSION }}"
+        do
+          docker tag ghcr.io/steamdeckhomebrew/holo-base:latest             ghcr.io/steamdeckhomebrew/holo-base:$tag
+          docker tag ghcr.io/steamdeckhomebrew/holo-toolchain-rust:latest   ghcr.io/steamdeckhomebrew/holo-toolchain-rust:$tag
+          docker tag ghcr.io/steamdeckhomebrew/holo-toolchain-go:latest     ghcr.io/steamdeckhomebrew/holo-toolchain-go:$tag
+        done
+
     - name: Wait for other runs to complete
       uses: softprops/turnstyle@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Push Base image
-      run: docker push ghcr.io/steamdeckhomebrew/holo-base:latest
+      run: docker push --all-tags ghcr.io/steamdeckhomebrew/holo-base
 
     - name: Push Rust toolchain image
-      run: docker push ghcr.io/steamdeckhomebrew/holo-toolchain-rust:latest
+      run: docker push --all-tags ghcr.io/steamdeckhomebrew/holo-toolchain-rust
 
     - name: Push Go toolchain image
-      run: docker push ghcr.io/steamdeckhomebrew/holo-toolchain-go:latest
+      run: docker push --all-tags ghcr.io/steamdeckhomebrew/holo-toolchain-go:latest
 
     - name: Log out of GitHub Container Registry
       run: |

--- a/download.sh
+++ b/download.sh
@@ -16,6 +16,6 @@ FILE=$(echo "$IMAGE" | jq -r ".update_path" | sed 's/\.raucb/\.img.zip/')
 # Output the downloaded version for github actions to tag the images
 echo "BUILD_ID=$(echo "$IMAGE" | jq -r '.image.buildid')"
 FULL_VERSION="$(echo "$IMAGE" | jq -r '.image.version')"
-echo "$FULL_VERSION=${FULL_VERSION}"
+echo "FULL_VERSION=${FULL_VERSION}"
 echo "MAJOR_VERSION=$(echo "$FULL_VERSION" | cut -d. -f 1)"
 echo "MINOR_VERSION=$(echo "$FULL_VERSION" | cut -d. -f 1,2)"

--- a/download.sh
+++ b/download.sh
@@ -3,8 +3,19 @@ set -e
 
 # these are hardcoded and can be found in ~/.netrc
 AUTH="jupiter-image-2021:e54fe7f0-756e-46e1-90d2-7843cda0ac01"
-FILE=$(curl -sS --user $AUTH "https://steamdeck-atomupd.steamos.cloud/updates?product=steamos&release=holo&variant=steamdeck&arch=amd64&version=snapshot&buildid=20220526.1&checkpoint=False&estimated_size=0" | jq -r ".minor.candidates[0].update_path" | sed 's/\.raucb/\.img.zip/')
-echo "Downloading image $FILE"
-curl --user $AUTH "https://steamdeck-images.steamos.cloud/$FILE" -o ./steamos.zip
-unzip ./steamos.zip -d ./steamos_image
-rm ./steamos.zip
+IMAGE="$(curl -sS --user $AUTH "https://steamdeck-atomupd.steamos.cloud/updates?product=steamos&release=holo&variant=steamdeck&arch=amd64&version=snapshot&buildid=20220526.1&checkpoint=False&estimated_size=0" | jq -r '.minor.candidates[0]')"
+FILE=$(echo "$IMAGE" | jq -r ".update_path" | sed 's/\.raucb/\.img.zip/')
+
+{
+    echo "Downloading image $FILE"
+    curl --user $AUTH "https://steamdeck-images.steamos.cloud/$FILE" -o ./steamos.zip
+    unzip ./steamos.zip -d ./steamos_image
+    rm ./steamos.zip
+} >&2
+
+# Output the downloaded version for github actions to tag the images
+echo "BUILD_ID=$(echo "$IMAGE" | jq -r '.image.buildid')"
+FULL_VERSION="$(echo "$IMAGE" | jq -r '.image.version')"
+echo "$FULL_VERSION=${FULL_VERSION}"
+echo "MAJOR_VERSION=$(echo "$FULL_VERSION" | cut -d. -f 1)"
+echo "MINOR_VERSION=$(echo "$FULL_VERSION" | cut -d. -f 1,2)"


### PR DESCRIPTION
This may be easiest to review commit-by-commit, particularly the Dockerfile. I [tested the build on my fork](https://github.com/ian-h-chamberlain/holo-docker/actions/runs/6256560625/job/16987576976) with my own credentials to make sure everything was working as well.

Changes: 
* Runners use Docker v24 now, which uses BuildKit by default. This broke the build when reinstalling `filesystem` due to moby/buildkit#1267
* Expand out the package list in the Dockerfile for easier diffs when adding/removing packages.
* Add `mesa-unstable` to the list of removed packages, it had some dependencies on other packages that are being removed
* Extract version info from the built image, and add tags for the version of SteamOS as well based on discussion from https://github.com/SteamDeckHomebrew/holo-docker/issues/4#issuecomment-1374337193