### PR TITLE
Make the image name configurable and get things working on the SteamDeck

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,20 +27,24 @@ jobs:
       run: ./download.sh
 
     - name: Build base image
-      run: sudo ./build.sh
+      run: |
+        cp example.env .env
+        sudo ./build.sh
 
     - name: Cleanup SteamOS image
       run: rm -rf ./steamos_image ./steamos
 
     - name: Build Rust toolchain image
       run: |
+        cp example.env .env
         cd languages
-        docker build -t ghcr.io/steamdeckhomebrew/holo-toolchain-rust:latest -f ./rust.dockerfile .
+        ./build.sh rust
 
     - name: Build Go toolchain image
       run: |
+        cp example.env .env
         cd languages
-        docker build -t ghcr.io/steamdeckhomebrew/holo-toolchain-go:latest -f ./go.dockerfile .
+        ./build.sh go
 
     - name: Wait for other runs to complete
       uses: softprops/turnstyle@v1
@@ -59,3 +63,4 @@ jobs:
     - name: Log out of GitHub Container Registry
       run: |
         docker logout ghcr.io
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 steamos
 steamos_image
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,7 @@ RUN pacman -R --noconfirm podman distrobox crun steamos-kdumpst-layer jupiter-st
  && pacman -S --noconfirm gcc make autoconf automake bison fakeroot flex m4 tpm2-tss \
  && yes | pacman -Scc
 
-FROM scratch
+FROM scratch as final
+
 COPY --from=builder / /
+

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Linux container images of SteamOS Holo
 
 ### SteamDeck
 
-These scripts should work just fine on an actual SteamDeck, assuming that it is up-to-date. However you will need to do just a little bit of setup, as the default location for container storage is much too small for this.
+These scripts should work just fine on an actual SteamDeck, assuming that SteamOS is up-to-date, and you are comfortable using the SteamDeck terminal. However you will need to do just a little bit of setup, as the default location for container storage is much too small for this.
 
 ```sh
 mkdir ~/containers
@@ -27,5 +27,5 @@ to
 
 - `graphroot = "/home/deck/containers/storage"`
 
-You will also need to use the `sudo` command when running the build and push scripts.
+You will also need to use the `sudo` command when running the top-level build and push scripts.
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # holo-docker
-Docker images of SteamOS Holo
+Linux container images of SteamOS Holo
+
+## Getting Started
+
+```sh
+./download.sh
+./build.sh
+./push_image.sh
+```
+
+### SteamDeck
+
+These scripts should work just fine on an actual SteamDeck, assuming that it is up-to-date. However you will need to do just a little bit of setup, as the default location for container storage is much too small for this.
+
+```sh
+mkdir ~/containers
+sudo cp -a /var/lib/container/storage ~/containers/storage
+sudo vim /etc/containers/storage.conf
+```
+
+Change the line that reads:
+
+- `graphroot = "/var/lib/containers/storage"`
+
+to
+
+- `graphroot = "/home/deck/containers/storage"`
+
+You will also need to use the `sudo` command when running the build and push scripts.
+

--- a/build.sh
+++ b/build.sh
@@ -1,15 +1,18 @@
 #!/bin/bash
 set -e
 
-LOOP=$(losetup --find --partscan --show ./steamos_image/disk.img)
-mkdir -p ./steamos
-mount ${LOOP}p3 ./steamos
-unmountimg() {
-    umount ./steamos
-    losetup -d $LOOP
+sudo losetup
+
+LOOP=$(sudo losetup --find --partscan --show ./steamos_image/disk.img)
+mkdir -p ${PWD}/steamos
+sudo btrfstune -M $(uuidgen) ${LOOP}p3
+sudo mount ${LOOP}p3 ${PWD}/steamos
+unmount_img() {
+    sudo umount ${PWD}/steamos
+    sudo losetup -d $LOOP
 }
 trap unmountimg ERR
 
-docker build -t ghcr.io/steamdeckhomebrew/holo-base:latest .
+sudo podman build -t docker.io/spkane/holo-base:latest .
 
-unmountimg
+unmount_img

--- a/build.sh
+++ b/build.sh
@@ -1,18 +1,38 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 set -e
 
-sudo losetup
+set -a
+if [[ -f ${PWD}/.env ]]; then
+  source ${PWD}/.env
+else
+  echo "[ERROR] Please copy 'example.env' to '.env' and edit values as desired."
+  exit 1
+fi
+set +a
 
-LOOP=$(sudo losetup --find --partscan --show ./steamos_image/disk.img)
+losetup
+
+LOOP=$(losetup --find --partscan --show ./steamos_image/disk.img)
 mkdir -p ${PWD}/steamos
-sudo btrfstune -M $(uuidgen) ${LOOP}p3
-sudo mount ${LOOP}p3 ${PWD}/steamos
+btrfstune -M $(uuidgen) ${LOOP}p3 # This allows us to mount this partition even if we are on a real SteamDeck.
+mount ${LOOP}p3 ${PWD}/steamos
+
 unmount_img() {
-    sudo umount ${PWD}/steamos
-    sudo losetup -d $LOOP
+    umount ${PWD}/steamos
+    losetup -d $LOOP
 }
+
 trap unmountimg ERR
 
-sudo podman build -t docker.io/spkane/holo-base:latest .
+if command -v "docker" &> /dev/null; then
+  docker build -t ${IMAGE_BASE}/${IMAGE_NAME_ROOT}-base:${IMAGE_TAG} .
+elif command -v "podman" &> /dev/null; then
+  podman build -t ${IMAGE_BASE}/${IMAGE_NAME_ROOT}-base:${IMAGE_TAG} .
+else
+  echo "[ERROR] You must have 'docker' or 'podman' installed."
+  exit 1
+fi
 
 unmount_img
+

--- a/download.sh
+++ b/download.sh
@@ -1,10 +1,12 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
 set -e
 
-# these are hardcoded and can be found in ~/.netrc
+# These are hardcoded and can be found in ~/.netrc on the SteamDeck filesystem image
 AUTH="jupiter-image-2021:e54fe7f0-756e-46e1-90d2-7843cda0ac01"
 FILE=$(curl -sS --user $AUTH "https://steamdeck-atomupd.steamos.cloud/updates?product=steamos&release=holo&variant=steamdeck&arch=amd64&version=snapshot&buildid=20220526.1&checkpoint=False&estimated_size=0" | jq -r ".minor.candidates[0].update_path" | sed 's/\.raucb/\.img.zip/')
 echo "Downloading image $FILE"
 curl --user $AUTH "https://steamdeck-images.steamos.cloud/$FILE" -o ./steamos.zip
 unzip ./steamos.zip -d ./steamos_image
 rm ./steamos.zip
+

--- a/example.env
+++ b/example.env
@@ -1,0 +1,3 @@
+IMAGE_BASE="ghcr.io/steamdeckhomebrew"
+IMAGE_NAME_ROOT="holo"
+IMAGE_TAG="latest"

--- a/languages/build.sh
+++ b/languages/build.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ $# != 1 ]]; then
+  echo "[ERROR] Exactly one argument is expected that matches the first part of one of the dockerfile names (e.g. 'go')"
+  exit 1
+fi
+
+DIR="$(dirname "$(realpath "$0")")"
+
+cd ${DIR}
+
+if [[ ! -f "${1}.dockerfile" ]]; then
+  echo "[ERROR] Could not find '${1}.dockerfile' in the same directory as this script."
+  exit 1
+fi
+
+set -a
+if [[ -f ${PWD}/../.env ]]; then
+  source ${PWD}/../.env
+else
+  echo "[ERROR] Please copy 'example.env' to '.env' in the repo root and edit values as desired."
+  exit 1
+fi
+set +a
+
+if command -v "docker" &> /dev/null; then
+  docker build -f "${1}.dockerfile" \
+    --build-arg="image_name=${IMAGE_BASE}/${IMAGE_NAME_ROOT}-base" \
+    -t ${IMAGE_BASE}/${IMAGE_NAME_ROOT}-toolchain-${1}:${IMAGE_TAG} .
+elif command -v "podman" &> /dev/null; then
+  podman build -f "${1}.dockerfile" \
+    --build-arg="image_name=${IMAGE_BASE}/${IMAGE_NAME_ROOT}-base" \
+    -t ${IMAGE_BASE}/${IMAGE_NAME_ROOT}-toolchain-${1}:${IMAGE_TAG} .
+else
+  echo "[ERROR] You must have 'docker' or 'podman' installed."
+  exit 1
+fi
+

--- a/languages/go.dockerfile
+++ b/languages/go.dockerfile
@@ -1,3 +1,5 @@
-FROM docker.io/spkane/holo-base:latest
+ARG image_name
+
+FROM ${image_name}
 
 RUN pacman -Sy --noconfirm go go-tools

--- a/languages/go.dockerfile
+++ b/languages/go.dockerfile
@@ -1,3 +1,3 @@
-FROM ghcr.io/steamdeckhomebrew/holo-base:latest
+FROM docker.io/spkane/holo-base:latest
 
 RUN pacman -Sy --noconfirm go go-tools

--- a/languages/push_image.sh
+++ b/languages/push_image.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ $# != 1 ]]; then
+  echo "[ERROR] Exactly one argument is expected that matches the first part of one of the dockerfile names (e.g. 'go')"
+  exit 1
+fi
+
+set -a
+if [[ -f ${PWD}/../.env ]]; then
+  source ${PWD}/../.env
+else
+  echo "[ERROR] Please copy 'example.env' to '.env' and edit values as desired."
+  exit 1
+fi
+set +a
+
+if command -v "docker" &> /dev/null; then
+  docker login ${IMAGE_BASE}
+  docker image push ${IMAGE_BASE}/${IMAGE_NAME_ROOT}-toolchain-${1}:${IMAGE_TAG}
+elif command -v "podman" &> /dev/null; then
+  podman login ${IMAGE_BASE}
+  podman image push ${IMAGE_BASE}/${IMAGE_NAME_ROOT}-toolchain-${1}:${IMAGE_TAG}
+else
+  echo "[ERROR] You must have 'docker' or 'podman' installed."
+  exit 1
+fi
+

--- a/languages/rust.dockerfile
+++ b/languages/rust.dockerfile
@@ -1,3 +1,5 @@
-FROM docker.io/spkane/holo-base:latest
+ARG image_name
+
+FROM ${image_name}
 
 RUN pacman -Sy --noconfirm rustup && rustup install stable

--- a/languages/rust.dockerfile
+++ b/languages/rust.dockerfile
@@ -1,3 +1,3 @@
-FROM ghcr.io/steamdeckhomebrew/holo-base:latest
+FROM docker.io/spkane/holo-base:latest
 
 RUN pacman -Sy --noconfirm rustup && rustup install stable

--- a/push_image.sh
+++ b/push_image.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+
+set -a
+if [[ -f ${PWD}/.env ]]; then
+  source ${PWD}/.env
+else
+  echo "[ERROR] Please copy 'example.env' to '.env' and edit values as desired."
+  exit 1
+fi
+set +a
+
+if command -v "docker" &> /dev/null; then
+  docker login ${IMAGE_BASE%%/*}
+  docker image push ${IMAGE_BASE}/${IMAGE_NAME_ROOT}-base:${IMAGE_TAG}
+elif command -v "podman" &> /dev/null; then
+  podman login ${IMAGE_BASE%%/*}
+  podman image push ${IMAGE_BASE}/${IMAGE_NAME_ROOT}-base:${IMAGE_TAG}
+else
+  echo "[ERROR] You must have 'docker' or 'podman' installed."
+  exit 1
+fi
+


### PR DESCRIPTION
I happened to be giving this a try on my SteamDeck and was able to get things working well with a few tweaks.

In general, this:

- Makes the image repo, image name, and image tag configurable.
  - Expands and adds a few scripts to facilitate the new flexibility.
- It also makes a few adjustments that allow this to work on a real SteamDeck.
  - Change the GUID on the image partition we want to mount, as it needs to be different then the real parition that is already mounted on the SteamDeck.
  - Use `podman` which is pre-installed on the SteamDeck.
  - Add some additional notes to the README.
