### PR TITLE
Fix Rust build on rootless (inaccessible binaries)

### DIFF
--- a/languages/rust.dockerfile
+++ b/languages/rust.dockerfile
@@ -1,3 +1,8 @@
 FROM ghcr.io/steamdeckhomebrew/holo-base:latest
 
+ENV RUSTUP_HOME=/.rustup
+ENV CARGO_HOME=/.cargo
+
+RUN mkdir /.rustup && chmod -R 777 /.rustup
+RUN mkdir /.cargo && chmod -R 777 /.cargo
 RUN pacman -Sy --noconfirm rustup && rustup install stable


### PR DESCRIPTION
This should allow all users to access rustup-installed binaries (e.g. the Rust compiler) in the container. Before this, non-root Rust builds would fail because /.rustup was inaccessible for the current user.